### PR TITLE
fix: fix a flaky test for SpannerQueryLookupStrategyTests

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -174,9 +174,12 @@ class SpannerQueryLookupStrategyTests {
             new SpannerWriteConverter(),
             this.spannerMappingContext);
     assertThat(statement.getSql())
-        .isEqualTo(
-            "SELECT deleted, id3, id, id_2 FROM child_test_table WHERE ((id = @tag0 AND id_2 ="
-                + " @tag1)) AND (deleted = false)");
+            .contains("SELECT ")
+            .contains("deleted")
+            .contains("id3")
+            .contains("id_2")
+            .contains("id")
+            .contains(" FROM child_test_table WHERE ((id = @tag0 AND id_2 = @tag1)) AND (deleted = false)");
     assertThat(statement.getParameters()).hasSize(2);
     assertThat(statement.getParameters().get("tag0").getString()).isEqualTo("key");
     assertThat(statement.getParameters().get("tag1").getString()).isEqualTo("key2");


### PR DESCRIPTION
A test in the API `getChildrenRowsQueryTest` checks for the result from `getSQL()` from `SpannerStatementQueryExecutor.getChildrenRowsQuery`. However, it checks the result in a specific order, which is not guaranteed. Here is the effected test:

```java
assertThat(statement.getSql())
        .isEqualTo(
            "SELECT deleted, id3, id, id_2 FROM child_test_table WHERE ((id = @tag0 AND id_2 ="
                + " @tag1)) AND (deleted = false)");
```

Here is the revised version:

```java
assertThat(statement.getSql())
            .contains("SELECT ")
            .contains("deleted")
            .contains("id3")
            .contains("id_2")
            .contains("id")
            .contains(" FROM child_test_table WHERE ((id = @tag0 AND id_2 = @tag1)) AND (deleted = false)");
```

This PR propose to simply check whether the selected field names are correct instead of checking in a specific order.